### PR TITLE
Move from pattern matching to if then

### DIFF
--- a/Program.fs
+++ b/Program.fs
@@ -6,7 +6,7 @@ open Spectre.Console
 
 type options = {
     [<Option('d', "dir", HelpText = "Directory containing GIFs to process.", Default="./")>] directory : string;
-    [<Option('r', "recursive", HelpText = "Recursively scan directories from root directory", Default=false)>] recursive: bool    
+    [<Option('r', "recursive", HelpText = "Recursively scan directories from root directory", Default=false)>] recursive: bool
 }
 
 let getFrameFromGif (path: string) : byte[] =
@@ -17,26 +17,25 @@ let getFrameFromGif (path: string) : byte[] =
     for y in 0..frame.Height-1 do
         for x in 0..frame.Width-1 do
             image.[x,y] <- source.[x,y]
-    use ms = new MemoryStream()    
+    use ms = new MemoryStream()
     image.SaveAsPng(ms)
     ms.ToArray()
-    
+
 let processFiles options : Unit =
-    match Directory.Exists options.directory with
-    | true ->
+    if Directory.Exists options.directory then
         let searchOption = if options.recursive then SearchOption.AllDirectories else SearchOption.TopDirectoryOnly
         let files = Directory.GetFiles(options.directory, "*.gif", searchOption)
-        let progress = AnsiConsole.Status()  
+        let progress = AnsiConsole.Status()
         let processEachFile (ctx:StatusContext) =
             for path in files do
                 let bytes = getFrameFromGif path
                 let filename = Path.GetFileNameWithoutExtension path
-                let target = $"%s{filename}.png"            
-                AnsiConsole.MarkupLine $"[green]:check_mark: Processing %s{Path.GetFileName path} -> %s{target}[/]"            
+                let target = $"%s{filename}.png"
+                AnsiConsole.MarkupLine $"[green]:check_mark: Processing %s{Path.GetFileName path} -> %s{target}[/]"
                 File.WriteAllBytes(target, bytes)
         progress.Start($"processing {files.Length} GIFs", processEachFile)
         AnsiConsole.MarkupLine($"[green]:glowing_star: { files.Length} GIFs processed in {options.directory}[/]")
-    | false ->
+    else
         AnsiConsole.MarkupLine $"[red]:exclamation_question_mark: Directory '{options.directory}' does not exist[/]"
 
 [<EntryPoint>]


### PR DESCRIPTION
Apologies for the extra changes in the PR - it's just VS Code removing extra whitespace. The only changes of note are actually in lines 25 and 38 - removing a pattern match on boolean with if / then. In F#, since if / then is an expression, it's more like a specialised form of pattern match designed explicitly for true / false.