### PR TITLE
Capitalise type. remove unnecessary type annotations.

### DIFF
--- a/Program.fs
+++ b/Program.fs
@@ -4,12 +4,12 @@ open SixLabors.ImageSharp.PixelFormats
 open CommandLine
 open Spectre.Console
 
-type options = {
+type Options = {
     [<Option('d', "dir", HelpText = "Directory containing GIFs to process.", Default="./")>] directory : string;
-    [<Option('r', "recursive", HelpText = "Recursively scan directories from root directory", Default=false)>] recursive: bool    
+    [<Option('r', "recursive", HelpText = "Recursively scan directories from root directory", Default=false)>] recursive: bool
 }
 
-let getFrameFromGif (path: string) : byte[] =
+let getFrameFromGif (path : string) =
     let gif = Image.Load(path)
     let frame = gif.Frames.RootFrame
     use image = new Image<Rgba32>(frame.Width, frame.Height)
@@ -17,22 +17,22 @@ let getFrameFromGif (path: string) : byte[] =
     for y in 0..frame.Height-1 do
         for x in 0..frame.Width-1 do
             image.[x,y] <- source.[x,y]
-    use ms = new MemoryStream()    
+    use ms = new MemoryStream()
     image.SaveAsPng(ms)
     ms.ToArray()
-    
-let processFiles options : Unit =
+
+let processFiles options =
     match Directory.Exists options.directory with
     | true ->
         let searchOption = if options.recursive then SearchOption.AllDirectories else SearchOption.TopDirectoryOnly
         let files = Directory.GetFiles(options.directory, "*.gif", searchOption)
-        let progress = AnsiConsole.Status()  
-        let processEachFile (ctx:StatusContext) =
+        let progress = AnsiConsole.Status()
+        let processEachFile _ =
             for path in files do
                 let bytes = getFrameFromGif path
                 let filename = Path.GetFileNameWithoutExtension path
-                let target = $"%s{filename}.png"            
-                AnsiConsole.MarkupLine $"[green]:check_mark: Processing %s{Path.GetFileName path} -> %s{target}[/]"            
+                let target = $"{filename}.png"
+                AnsiConsole.MarkupLine $"[green]:check_mark: Processing {Path.GetFileName path} -> {target}[/]"
                 File.WriteAllBytes(target, bytes)
         progress.Start($"processing {files.Length} GIFs", processEachFile)
         AnsiConsole.MarkupLine($"[green]:glowing_star: { files.Length} GIFs processed in {options.directory}[/]")
@@ -41,9 +41,9 @@ let processFiles options : Unit =
 
 [<EntryPoint>]
 let main argv =
-    let result = Parser.Default.ParseArguments<options>(argv)
+    let result = Parser.Default.ParseArguments<Options>(argv)
     match result with
-    | :? Parsed<options> as parsed -> processFiles parsed.Value
-    | :? NotParsed<options> as incorrect -> printf $"Invalid: %A{argv}, Errors: %u{Seq.length incorrect.Errors}"
+    | :? Parsed<Options> as parsed -> processFiles parsed.Value
+    | :? NotParsed<Options> as incorrect -> printf $"Invalid: %A{argv}, Errors: %u{Seq.length incorrect.Errors}"
     | _ -> failwith "Unknown parsing error"
     0


### PR DESCRIPTION
Types should normally be capitalised, so `Options` instead of `options`. I also removed a couple of unnecessary type annotations that the compile would be able to figure out.