### PR TITLE
Typesafe cast to Image<Rgba32>

### DIFF
--- a/Program.fs
+++ b/Program.fs
@@ -39,10 +39,9 @@ let processFiles options : Unit =
                     let filename = Path.GetFileNameWithoutExtension path
                     let target = $"%s{filename}.png"
                     AnsiConsole.MarkupLine $"[green]{CheckMark} Processing %s{Path.GetFileName path} -> %s{target}[/]"
-                    AnsiConsole.MarkupLine $"[yellow]{Warning} Image {Path.GetFileName path} was not a valid ImageFrame, skipping[/]"
                     File.WriteAllBytes(target, bytes)
                 | None ->
-                    ()
+                    AnsiConsole.MarkupLine $"[yellow]{Warning} Image {Path.GetFileName path} was not a valid ImageFrame, skipping[/]"
 
         progress.Start($"processing {files.Length} GIFs", processEachFile)
         AnsiConsole.MarkupLine($"[green]{GlowingStar} { files.Length} GIFs processed in {options.directory}[/]")

--- a/Program.fs
+++ b/Program.fs
@@ -3,41 +3,51 @@ open SixLabors.ImageSharp
 open SixLabors.ImageSharp.PixelFormats
 open CommandLine
 open Spectre.Console
+open type Emoji.Known
 
 type options = {
     [<Option('d', "dir", HelpText = "Directory containing GIFs to process.", Default="./")>] directory : string;
-    [<Option('r', "recursive", HelpText = "Recursively scan directories from root directory", Default=false)>] recursive: bool    
+    [<Option('r', "recursive", HelpText = "Recursively scan directories from root directory", Default=false)>] recursive: bool
 }
 
-let getFrameFromGif (path: string) : byte[] =
+let getFrameFromGif (path: string) : byte[] option =
     let gif = Image.Load(path)
     let frame = gif.Frames.RootFrame
     use image = new Image<Rgba32>(frame.Width, frame.Height)
-    let source = frame :?> ImageFrame<Rgba32>
-    for y in 0..frame.Height-1 do
-        for x in 0..frame.Width-1 do
-            image.[x,y] <- source.[x,y]
-    use ms = new MemoryStream()    
-    image.SaveAsPng(ms)
-    ms.ToArray()
-    
+    match frame with
+    | :? ImageFrame<Rgba32> as source ->
+        for y in 0..frame.Height-1 do
+            for x in 0..frame.Width-1 do
+                image.[x,y] <- source.[x,y]
+        use ms = new MemoryStream()
+        image.SaveAsPng(ms)
+        Some (ms.ToArray())
+    | _ ->
+        None
+
 let processFiles options : Unit =
     match Directory.Exists options.directory with
     | true ->
         let searchOption = if options.recursive then SearchOption.AllDirectories else SearchOption.TopDirectoryOnly
         let files = Directory.GetFiles(options.directory, "*.gif", searchOption)
-        let progress = AnsiConsole.Status()  
+        let progress = AnsiConsole.Status()
         let processEachFile (ctx:StatusContext) =
             for path in files do
                 let bytes = getFrameFromGif path
-                let filename = Path.GetFileNameWithoutExtension path
-                let target = $"%s{filename}.png"            
-                AnsiConsole.MarkupLine $"[green]:check_mark: Processing %s{Path.GetFileName path} -> %s{target}[/]"            
-                File.WriteAllBytes(target, bytes)
+                match bytes with
+                | Some bytes ->
+                    let filename = Path.GetFileNameWithoutExtension path
+                    let target = $"%s{filename}.png"
+                    AnsiConsole.MarkupLine $"[green]{CheckMark} Processing %s{Path.GetFileName path} -> %s{target}[/]"
+                    AnsiConsole.MarkupLine $"[yellow]{Warning} Image {Path.GetFileName path} was not a valid ImageFrame, skipping[/]"
+                    File.WriteAllBytes(target, bytes)
+                | None ->
+                    ()
+
         progress.Start($"processing {files.Length} GIFs", processEachFile)
-        AnsiConsole.MarkupLine($"[green]:glowing_star: { files.Length} GIFs processed in {options.directory}[/]")
+        AnsiConsole.MarkupLine($"[green]{GlowingStar} { files.Length} GIFs processed in {options.directory}[/]")
     | false ->
-        AnsiConsole.MarkupLine $"[red]:exclamation_question_mark: Directory '{options.directory}' does not exist[/]"
+        AnsiConsole.MarkupLine $"[red]{ExclamationQuestionMark} Directory '{options.directory}' does not exist[/]"
 
 [<EntryPoint>]
 let main argv =


### PR DESCRIPTION
This moves from `:?>` (unsafe cast) to pattern match type tests:

```fsharp
match frame with
| :? ImageFrame<Rgba32> as source ->
    ....
    Some (ms.ToArray())
| _ ->
    None
```

Then the caller needs to *explicitly* handle both cases:

```fsharp
match bytes with
| Some bytes ->
    ....
    AnsiConsole.MarkupLine $"[green]{CheckMark} Processing %s{Path.GetFileName path} -> %s{target}[/]"
| None ->
    AnsiConsole.MarkupLine $"[yellow]{Warning} Image {Path.GetFileName path} was not a valid ImageFrame, skipping[/]"
```

I also took the liberty of using Spectre's built-in support for Emojis for typesafe access to them.