### PR TITLE
More efficient frame copying.

### DIFF
--- a/Program.fs
+++ b/Program.fs
@@ -10,13 +10,10 @@ type options = {
 }
 
 let getFrameFromGif (path: string) : byte[] =
-    let gif = Image.Load(path)
-    let frame = gif.Frames.RootFrame
-    use image = new Image<Rgba32>(frame.Width, frame.Height)
-    let source = frame :?> ImageFrame<Rgba32>
-    for y in 0..frame.Height-1 do
-        for x in 0..frame.Width-1 do
-            image.[x,y] <- source.[x,y]
+    use gif = Image.Load(path)
+    use image = new Image<Rgba32>(gif.Width, gif.Height)
+    image.Frames.AddFrame(gif.Frames.RootFrame)|> ignore;
+    image.Frames.RemoveFrame(0);
     use ms = new MemoryStream()    
     image.SaveAsPng(ms)
     ms.ToArray()

--- a/readme.md
+++ b/readme.md
@@ -28,7 +28,7 @@ Copyright (C) 2021 FreezeFrame
 
 ## Licenses For ImageSharp
 
-- This tool uses [ImageSharp](https://sixlabors.com/products/imagesharp/), which requires a license for commercial use.
+- This tool uses [ImageSharp](https://sixlabors.com/products/imagesharp/), which requires a license for commercial support.
 
 ## License
 


### PR DESCRIPTION
Just saw your tweet asking me for assistance with the ImageSharp API. This is my first time writing F# so I'm hoping I got it right!

I replaced the `[x, y]` frame iteration with a more efficient cloning. I also fixed the leak for the initial gif.

I did spot something else but I'm not confident in my F# to do a fix.

I wouldn't return a byte array from the `getFrameFromGif` method, I'd return the stream and copy it to a filestream in order to remove the overhead of allocating and copying a new array for each time.